### PR TITLE
fix: restore correct Bash permission format and document workflow fix

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,6 @@
 {
   "allowedTools": [
     "Bash(./gradlew assembleDebug)",
-    "Bash(gh pr create*)"
+    "Bash(gh pr create:*)"
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,3 +22,5 @@ Android app written in Kotlin. Minimum SDK 26, target SDK 34.
 # PR Instructions
 Always create the PR yourself using: gh pr create --base main
 Never give the user a link to create the PR manually.
+
+**Note:** `gh pr create` requires `claude_args: "--allowedTools 'Bash(gh pr create:*)'"` in `.github/workflows/claude.yml` (see issue #13). Until the workflow is updated, provide a manual PR creation link as a fallback.


### PR DESCRIPTION
Restores `Bash(gh pr create:*)` format in settings.json and documents required workflow change.

Root cause: `allowed_tools` is not a valid claude-code-action@v1 input (silently ignored), and tag mode hardcodes --allowedTools without gh pr create. The workflow must use `claude_args: "--allowedTools 'Bash(gh pr create:*)'"` instead.

Closes #13

Generated with [Claude Code](https://claude.ai/code)